### PR TITLE
Warn the user if their Celery_broker connection is blank

### DIFF
--- a/adsputils/__init__.py
+++ b/adsputils/__init__.py
@@ -303,7 +303,7 @@ class ADSCelery(Celery):
         if 'broker' not in kwargs:
             kwargs['broker'] = self._config.get('CELERY_BROKER', 'pyamqp://'),
         if kwargs['broker'] == ('pyamqp://',):
-            print ('Warning: No value found for CELERY_BROKER, config.py may not be in the correct directory (see proj_home in tasks.py)')
+            print('Warning: No value found for CELERY_BROKER, config.py may not be in the correct directory (see proj_home in tasks.py)')
         if 'include' not in kwargs:
             cm = None
             if 'CELERY_INCLUDE' not in self._config:
@@ -581,4 +581,3 @@ def get_json_formatter(use_color=False,
                        logfmt = u'%(asctime)s,%(msecs)03d %(levelname)-8s [%(process)d:%(threadName)s:%(filename)s:%(lineno)d] %(message)s',
                        datefmt = TIMESTAMP_FMT):
     return JsonFormatter(logfmt, datefmt, extra={"hostname":socket.gethostname()}, use_color=use_color)
-    

--- a/adsputils/__init__.py
+++ b/adsputils/__init__.py
@@ -301,8 +301,8 @@ class ADSCelery(Celery):
 
         # make sure that few important params are set for celery
         if 'broker' not in kwargs:
-            kwargs['broker'] = self._config.get('CELERY_BROKER', 'pyamqp://')
-        if kwargs['broker'] == 'pyamqp://':
+            kwargs['broker'] = self._config.get('CELERY_BROKER', 'pyamqp://'),
+        if kwargs['broker'] == 'pyamqp://',:
             raise ValueError('No value given for CELERY_BROKER, config.py may not be in the correct directory (see proj_home in tasks.py)')
         if 'include' not in kwargs:
             cm = None

--- a/adsputils/__init__.py
+++ b/adsputils/__init__.py
@@ -301,7 +301,9 @@ class ADSCelery(Celery):
 
         # make sure that few important params are set for celery
         if 'broker' not in kwargs:
-            kwargs['broker'] = self._config.get('CELERY_BROKER', 'pyamqp://'),
+            kwargs['broker'] = self._config.get('CELERY_BROKER', 'pyamqp://')
+        if kwargs['broker'] == 'pyamqp://':
+            raise ValueError('No value given for CELERY_BROKER, config.py may not be in the correct directory (see proj_home in tasks.py)')
         if 'include' not in kwargs:
             cm = None
             if 'CELERY_INCLUDE' not in self._config:

--- a/adsputils/__init__.py
+++ b/adsputils/__init__.py
@@ -302,8 +302,8 @@ class ADSCelery(Celery):
         # make sure that few important params are set for celery
         if 'broker' not in kwargs:
             kwargs['broker'] = self._config.get('CELERY_BROKER', 'pyamqp://'),
-        if kwargs['broker'] == 'pyamqp://',:
-            raise ValueError('No value given for CELERY_BROKER, config.py may not be in the correct directory (see proj_home in tasks.py)')
+        if kwargs['broker'] == ('pyamqp://',):
+            print ('Warning: No value found for CELERY_BROKER, config.py may not be in the correct directory (see proj_home in tasks.py)')
         if 'include' not in kwargs:
             cm = None
             if 'CELERY_INCLUDE' not in self._config:


### PR DESCRIPTION
Further to issue #15, I made a small change to __init__.py:

After 304: print a warning if CELERY_BROKER is blank and has set kwargs['broker'] to ('pyamqp://',{}) (empty URL).