### PR TITLE
specify version of setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ DateTime==4.1.1
 celery==4.1.1
 SQLAlchemy==1.1.6
 python-json-logger==0.1.8
+setuptools<45
 unidecode==0.04.21


### PR DESCRIPTION
in new releases setuptools drops support for python2
see https://setuptools.readthedocs.io/en/latest/history.html#v45-0-0