### PR TITLE
adsmsg=1.3.5 requirement updated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-adsmsg==1.3.3
+adsmsg==1.3.5
 concurrent-log-handler==0.9.20
 python-dateutil==2.8.1
 DateTime==4.1.1


### PR DESCRIPTION
Updated requirements.txt to use latest version of ADSPipelineMsg https://pypi.org/project/adsmsg/